### PR TITLE
Enterprise fixes 2

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.14
-      - uses: engineerd/setup-kind@v0.4.0
+      - uses: engineerd/setup-kind@v0.5.0
         with:
           skipClusterCreation: "true"
           version: v0.8.0
@@ -135,7 +135,7 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.14
-      - uses: engineerd/setup-kind@v0.4.0
+      - uses: engineerd/setup-kind@v0.5.0
         with:
           skipClusterCreation: "true"
           version: v0.8.0

--- a/ci/setup-funcs.sh
+++ b/ci/setup-funcs.sh
@@ -413,7 +413,7 @@ function install_gloomesh() {
   cluster=$1
   apiServerAddress=$(get_api_address ${cluster})
 
-  ${PROJECT_ROOT}/ci/setup-gloomesh.sh ${cluster} ${GLOOMESH_CHART} ${AGENT_CHART} ${AGENT_IMAGE} ${apiServerAddress}
+  bash ${PROJECT_ROOT}/ci/setup-gloomesh.sh ${cluster} ${GLOOMESH_CHART} ${AGENT_CHART} ${AGENT_IMAGE} ${apiServerAddress}
 
   if [ ! -z ${POST_INSTALL_SCRIPT} ]; then
     bash ${POST_INSTALL_SCRIPT}

--- a/ci/setup-funcs.sh
+++ b/ci/setup-funcs.sh
@@ -390,6 +390,9 @@ function register_cluster() {
 
   echo "registering ${cluster} with local cert-agent image..."
 
+  # needed for the agent chart
+  setChartVariables
+
   # load cert-agent image
   kind load docker-image --name "${cluster}" "${AGENT_IMAGE}"
 
@@ -401,9 +404,6 @@ function register_cluster() {
   if [ ${INSTALL_WASM_AGENT} == "1" ]; then
     EXTRA_FLAGS="--install-wasm-agent --wasm-agent-chart-file=${WASM_AGENT_CHART}"
   fi
-
-  # needwd for the agent chart
-  setChartVariables
 
   go run "${PROJECT_ROOT}/cmd/meshctl/main.go" cluster register \
     --cluster-name "${cluster}" \

--- a/ci/setup-funcs.sh
+++ b/ci/setup-funcs.sh
@@ -4,21 +4,6 @@
 # Functions for setting up kind clusters
 #####################################
 
-#!/bin/bash
-
-INSTALL_DIR=${PROJECT_ROOT}/install
-AGENT_VALUES=${INSTALL_DIR}/helm/cert-agent/values.yaml
-AGENT_IMAGE_REGISTRY=$(cat ${AGENT_VALUES} | grep "registry: " | awk '{print $2}')
-AGENT_IMAGE_REPOSITORY=$(cat ${AGENT_VALUES} | grep "repository: " | awk '{print $2}')
-AGENT_IMAGE_TAG=$(cat ${AGENT_VALUES} | grep "tag: " | awk '{print $2}' | sed 's/"//g')
-
-AGENT_IMAGE=${AGENT_IMAGE_REGISTRY}/${AGENT_IMAGE_REPOSITORY}:${AGENT_IMAGE_TAG}
-AGENT_CHART=${INSTALL_DIR}/helm/_output/charts/cert-agent/cert-agent-${AGENT_IMAGE_TAG}.tgz
-
-GLOOMESH_VALUES=${INSTALL_DIR}/helm/gloo-mesh/values.yaml
-GLOOMESH_IMAGE_TAG=$(cat ${GLOOMESH_VALUES} | grep -m 1 "tag: " | awk '{print $2}' | sed 's/"//g')
-GLOOMESH_CHART=${INSTALL_DIR}/helm/_output/charts/gloo-mesh/gloo-mesh-${GLOOMESH_IMAGE_TAG}.tgz
-
 #### FUNCTIONS
 
 function create_kind_cluster() {
@@ -410,10 +395,11 @@ function register_cluster() {
 }
 
 function install_gloomesh() {
+
   cluster=$1
   apiServerAddress=$(get_api_address ${cluster})
 
-  bash ${PROJECT_ROOT}/ci/setup-gloomesh.sh ${cluster} ${GLOOMESH_CHART} ${AGENT_CHART} ${AGENT_IMAGE} ${apiServerAddress}
+  bash ${PROJECT_ROOT}/ci/setup-gloomesh.sh ${cluster} ${apiServerAddress}
 
   if [ ! -z ${POST_INSTALL_SCRIPT} ]; then
     bash ${POST_INSTALL_SCRIPT}

--- a/ci/setup-gloomesh.sh
+++ b/ci/setup-gloomesh.sh
@@ -7,10 +7,7 @@
 #####################################
 
 cluster=$1
-glooMeshChart=$2
-agentChart=$3
-agentImage=$4
-apiServerAddress=$5
+apiServerAddress=$2
 
 PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
 
@@ -24,10 +21,22 @@ echo "deploying gloo-mesh to ${cluster} from local images..."
 
 ## build and load GlooMesh docker images
 MAKE="make -C $PROJECT_ROOT"
-eval "${MAKE} manifest-gen package-helm build-all-images -B"
+eval "${MAKE} clean-helm manifest-gen package-helm build-all-images -B"
 
 INSTALL_DIR="${PROJECT_ROOT}/install/"
 DEFAULT_MANIFEST="${INSTALL_DIR}/gloo-mesh-default.yaml"
+
+AGENT_VALUES=${INSTALL_DIR}/helm/cert-agent/values.yaml
+AGENT_IMAGE_REGISTRY=$(cat ${AGENT_VALUES} | grep "registry: " | awk '{print $2}')
+AGENT_IMAGE_REPOSITORY=$(cat ${AGENT_VALUES} | grep "repository: " | awk '{print $2}')
+AGENT_IMAGE_TAG=$(cat ${AGENT_VALUES} | grep "tag: " | awk '{print $2}' | sed 's/"//g')
+
+agentChart=${INSTALL_DIR}/helm/_output/charts/cert-agent/cert-agent-${AGENT_IMAGE_TAG}.tgz
+agentImage=${AGENT_IMAGE_REGISTRY}/${AGENT_IMAGE_REPOSITORY}:${AGENT_IMAGE_TAG}
+
+GLOOMESH_VALUES=${INSTALL_DIR}/helm/gloo-mesh/values.yaml
+GLOOMESH_IMAGE_TAG=$(cat ${GLOOMESH_VALUES} | grep -m 1 "tag: " | awk '{print $2}' | sed 's/"//g')
+glooMeshChart=${INSTALL_DIR}/helm/_output/charts/gloo-mesh/gloo-mesh-${GLOOMESH_IMAGE_TAG}.tgz
 
 # load GlooMesh discovery and networking images
 grep "image:" "${DEFAULT_MANIFEST}" \

--- a/ci/setup-gloomesh.sh
+++ b/ci/setup-gloomesh.sh
@@ -10,6 +10,7 @@ cluster=$1
 apiServerAddress=$2
 
 PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
+source ${PROJECT_ROOT}/ci/setup-funcs.sh
 
 if [ "${cluster}" == "" ]; then
   cluster=mgmt-cluster
@@ -23,20 +24,11 @@ echo "deploying gloo-mesh to ${cluster} from local images..."
 MAKE="make -C $PROJECT_ROOT"
 eval "${MAKE} clean-helm manifest-gen package-helm build-all-images -B"
 
-INSTALL_DIR="${PROJECT_ROOT}/install/"
-DEFAULT_MANIFEST="${INSTALL_DIR}/gloo-mesh-default.yaml"
+setChartVariables
 
-AGENT_VALUES=${INSTALL_DIR}/helm/cert-agent/values.yaml
-AGENT_IMAGE_REGISTRY=$(cat ${AGENT_VALUES} | grep "registry: " | awk '{print $2}')
-AGENT_IMAGE_REPOSITORY=$(cat ${AGENT_VALUES} | grep "repository: " | awk '{print $2}')
-AGENT_IMAGE_TAG=$(cat ${AGENT_VALUES} | grep "tag: " | awk '{print $2}' | sed 's/"//g')
-
-agentChart=${INSTALL_DIR}/helm/_output/charts/cert-agent/cert-agent-${AGENT_IMAGE_TAG}.tgz
-agentImage=${AGENT_IMAGE_REGISTRY}/${AGENT_IMAGE_REPOSITORY}:${AGENT_IMAGE_TAG}
-
-GLOOMESH_VALUES=${INSTALL_DIR}/helm/gloo-mesh/values.yaml
-GLOOMESH_IMAGE_TAG=$(cat ${GLOOMESH_VALUES} | grep -m 1 "tag: " | awk '{print $2}' | sed 's/"//g')
-glooMeshChart=${INSTALL_DIR}/helm/_output/charts/gloo-mesh/gloo-mesh-${GLOOMESH_IMAGE_TAG}.tgz
+agentChart=${AGENT_CHART}
+agentImage=${AGENT_IMAGE}
+gloomeshChart=${GLOOMESH_CHART}
 
 # load GlooMesh discovery and networking images
 grep "image:" "${DEFAULT_MANIFEST}" \
@@ -51,7 +43,7 @@ kind load docker-image --name "${cluster}" "${agentImage}"
 
 go run "${PROJECT_ROOT}/cmd/meshctl/main.go" install \
   --kubecontext kind-"${cluster}" \
-  --chart-file "${glooMeshChart}" \
+  --chart-file "${gloomeshChart}" \
   --namespace gloo-mesh \
   --register \
   --cluster-name "${cluster}" \

--- a/ci/setup-kind.sh
+++ b/ci/setup-kind.sh
@@ -50,18 +50,18 @@ else
 
   # NOTE(ilackarms): we run the setup_kind clusters sequentially due to this bug:
   # related: https://github.com/kubernetes-sigs/kind/issues/1596
-  create_kind_cluster ${mgmtCluster} 32001  || echo SKIPPED
+  create_kind_cluster ${mgmtCluster} 32001
   install_istio ${mgmtCluster} 32001 &
 
-  create_kind_cluster ${remoteCluster} 32000  || echo SKIPPED
+  create_kind_cluster ${remoteCluster} 32000
   install_istio ${remoteCluster} 32000 &
 
   wait
 
   # create istio-injectable namespace
-  kubectl --context kind-${mgmtCluster} create namespace bookinfo  || echo SKIPPED
+  kubectl --context kind-${mgmtCluster} create namespace bookinfo
   kubectl --context kind-${mgmtCluster} label ns bookinfo istio-injection=enabled --overwrite
-  kubectl --context kind-${remoteCluster} create namespace bookinfo  || echo SKIPPED
+  kubectl --context kind-${remoteCluster} create namespace bookinfo
   kubectl --context kind-${remoteCluster} label ns bookinfo istio-injection=enabled --overwrite
 
   # install bookinfo without reviews-v3 to management cluster

--- a/ci/setup-kind.sh
+++ b/ci/setup-kind.sh
@@ -48,18 +48,18 @@ else
 
   # NOTE(ilackarms): we run the setup_kind clusters sequentially due to this bug:
   # related: https://github.com/kubernetes-sigs/kind/issues/1596
-  create_kind_cluster ${mgmtCluster} 32001
+  create_kind_cluster ${mgmtCluster} 32001  || echo SKIPPED
   install_istio ${mgmtCluster} 32001 &
 
-  create_kind_cluster ${remoteCluster} 32000
+  create_kind_cluster ${remoteCluster} 32000  || echo SKIPPED
   install_istio ${remoteCluster} 32000 &
 
   wait
 
   # create istio-injectable namespace
-  kubectl --context kind-${mgmtCluster} create namespace bookinfo
+  kubectl --context kind-${mgmtCluster} create namespace bookinfo  || echo SKIPPED
   kubectl --context kind-${mgmtCluster} label ns bookinfo istio-injection=enabled --overwrite
-  kubectl --context kind-${remoteCluster} create namespace bookinfo
+  kubectl --context kind-${remoteCluster} create namespace bookinfo  || echo SKIPPED
   kubectl --context kind-${remoteCluster} label ns bookinfo istio-injection=enabled --overwrite
 
   # install bookinfo without reviews-v3 to management cluster

--- a/ci/setup-kind.sh
+++ b/ci/setup-kind.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -ex
 
+set -o xtrace
+
 #####################################
 #
 # Set up two kind clusters:

--- a/pkg/mesh-networking/start.go
+++ b/pkg/mesh-networking/start.go
@@ -41,7 +41,13 @@ func startReconciler(
 		appmesh.NewAppmeshTranslator(),
 		osm.NewOSMTranslator(),
 	)
-	applier := apply.NewApplier(translator)
+
+	validatingTranslator := translation.NewTranslator(
+		istio.NewIstioTranslator(nil), // the applier should not call the extender
+		appmesh.NewAppmeshTranslator(),
+		osm.NewOSMTranslator(),
+	)
+	applier := apply.NewApplier(validatingTranslator)
 
 	startCertIssuer(
 		parameters.Ctx,

--- a/pkg/mesh-networking/translation/istio/extensions/istio_networking_extender.go
+++ b/pkg/mesh-networking/translation/istio/extensions/istio_networking_extender.go
@@ -33,6 +33,9 @@ func NewIstioExtender(clientset extensions.Clientset) *istioExtender {
 }
 
 func (i *istioExtender) PatchOutputs(ctx context.Context, inputs input.Snapshot, outputs istio.Builder) error {
+	if i.clientset == nil {
+		return nil
+	}
 	for _, exClient := range i.clientset.GetClients() {
 		patches, err := exClient.GetExtensionPatches(ctx, &v1alpha1.ExtensionPatchRequest{
 			Inputs:  extensions.InputSnapshotToProto(inputs),

--- a/pkg/mesh-networking/translation/istio/istio_networking_translator.go
+++ b/pkg/mesh-networking/translation/istio/istio_networking_translator.go
@@ -34,13 +34,13 @@ type istioTranslator struct {
 
 	// note: these interfaces are set directly in unit tests, but not exposed in the Translator's constructor
 	dependencies internal.DependencyFactory
-	extensions   istioextensions.IstioExtender
+	extender     istioextensions.IstioExtender
 }
 
 func NewIstioTranslator(extensionClients extensions.Clientset) Translator {
 	return &istioTranslator{
 		dependencies: internal.NewDependencyFactory(),
-		extensions:   istioextensions.NewIstioExtender(extensionClients),
+		extender:     istioextensions.NewIstioExtender(extensionClients),
 	}
 }
 
@@ -77,8 +77,8 @@ func (t *istioTranslator) Translate(
 		meshTranslator.Translate(in, mesh, istioOutputs, localOutputs, reporter)
 	}
 
-	if err := t.extensions.PatchOutputs(ctx, in, istioOutputs); err != nil {
-		// TODO(ilackarms): consider providing/checking user option to fail here when the extensions server is unavailable.
+	if err := t.extender.PatchOutputs(ctx, in, istioOutputs); err != nil {
+		// TODO(ilackarms): consider providing/checking user option to fail here when the extender server is unavailable.
 		// currently we just log the error and continue.
 		contextutils.LoggerFrom(ctx).Errorf("failed to apply extension patches: %v", err)
 	}

--- a/pkg/mesh-networking/translation/istio/istio_networking_translator_test.go
+++ b/pkg/mesh-networking/translation/istio/istio_networking_translator_test.go
@@ -46,7 +46,7 @@ var _ = Describe("IstioNetworkingTranslator", func() {
 		mockDependencyFactory = mock_istio.NewMockDependencyFactory(ctrl)
 		mockIstioOutputs = mock_istio_output.NewMockBuilder(ctrl)
 		mockLocalOutputs = mock_local_output.NewMockBuilder(ctrl)
-		translator = &istioTranslator{dependencies: mockDependencyFactory, extensions: mockIstioExtender}
+		translator = &istioTranslator{dependencies: mockDependencyFactory, extender: mockIstioExtender}
 	})
 
 	AfterEach(func() {

--- a/test/e2e/env.go
+++ b/test/e2e/env.go
@@ -230,7 +230,7 @@ func StartEnv(ctx context.Context) Env {
 	Expect(err).NotTo(HaveOccurred())
 
 	// get absolute path to setup script so this function can be called from any working directory)
-	cmd := exec.CommandContext(ctx, "./ci/setup-kind.sh", strconv.Itoa(GinkgoParallelNode()))
+	cmd := exec.CommandContext(ctx, "bash", "./ci/setup-kind.sh", strconv.Itoa(GinkgoParallelNode()))
 	cmd.Stdout = GinkgoWriter
 	cmd.Stderr = GinkgoWriter
 	cmd.Env = os.Environ()


### PR DESCRIPTION
includes 2 fixes:
- do not call extensions server during `applier` translation
- make ci scripts callable from another repo (enterpirse repo)

also makes the scripts re-runnable (will not exit if cluster / namespace creation fails). i can undo this if desired (but definitely helps with local development)