### PR TITLE
Fix unsupported protocol issue

### DIFF
--- a/changelog/v0.10.10/fed-ports.yaml
+++ b/changelog/v0.10.10/fed-ports.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo-mesh/issues/1146
+    description: Fallback to port protocol when failing to determine App Protocol for federation translation.

--- a/pkg/mesh-networking/translation/istio/mesh/federation/federation_translator.go
+++ b/pkg/mesh-networking/translation/istio/mesh/federation/federation_translator.go
@@ -31,6 +31,7 @@ import (
 	networkingv1alpha3spec "istio.io/api/networking/v1alpha3"
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"istio.io/istio/pkg/config/kube"
+	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/envoy/config/filter/network/tcp_cluster_rewrite/v2alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -387,5 +388,9 @@ func convertKubePortProtocol(port *discoveryv1alpha2.TrafficTargetSpec_KubeServi
 	if port.AppProtocol != "" {
 		appProtocol = pointer.StringPtr(port.AppProtocol)
 	}
-	return string(kube.ConvertProtocol(int32(port.Port), port.Name, corev1.Protocol(port.Protocol), appProtocol))
+	convertedProtocol := kube.ConvertProtocol(int32(port.Port), port.Name, corev1.Protocol(port.Protocol), appProtocol)
+	if convertedProtocol == protocol.Unsupported {
+		return port.Protocol
+	}
+	return string(convertedProtocol)
 }

--- a/pkg/mesh-networking/translation/istio/mesh/federation/federation_translator_test.go
+++ b/pkg/mesh-networking/translation/istio/mesh/federation/federation_translator_test.go
@@ -111,6 +111,11 @@ var _ = Describe("FederationTranslator", func() {
 							Protocol: "TCP",
 						},
 						{
+							Port:     5555,
+							Name:     "status-port",
+							Protocol: "TCP",
+						},
+						{
 							Port:     5678,
 							Name:     "grpc",
 							Protocol: "TCP",
@@ -317,6 +322,11 @@ var expectedServiceEntries = istiov1alpha3sets.NewServiceEntrySet(&networkingv1a
 				Name:     "http",
 			},
 			{
+				Number:   5555,
+				Protocol: string(protocol.TCP),
+				Name:     "status-port",
+			},
+			{
 				Number:   5678,
 				Protocol: string(protocol.GRPC),
 				Name:     "grpc",
@@ -328,8 +338,9 @@ var expectedServiceEntries = istiov1alpha3sets.NewServiceEntrySet(&networkingv1a
 			{
 				Address: "mesh-gateway.dns.name",
 				Ports: map[string]uint32{
-					"http": 8181,
-					"grpc": 8181,
+					"http":        8181,
+					"grpc":        8181,
+					"status-port": 8181,
 				},
 				Labels: map[string]string{"cluster": "cluster"},
 			},


### PR DESCRIPTION
BOT NOTES: 
resolves https://github.com/solo-io/gloo-mesh/issues/1146

with this change:
```yaml
apiVersion: networking.mesh.gloo.solo.io/v1alpha2
kind: VirtualMesh
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"networking.mesh.gloo.solo.io/v1alpha2","kind":"VirtualMesh","metadata":{"annotations":{},"name":"virtual-mesh","namespace":"gloo-mesh"},"spec":{"federation":{"permissive":{}},"meshes":[{"name":"istiod-istio-system-cluster1","namespace":"gloo-mesh"},{"name":"istiod-istio-system-cluster2","namespace":"gloo-mesh"}],"mtlsConfig":{"autoRestartPods":true,"shared":{"rootCertificateAuthority":{"generated":{}}}}}}
  creationTimestamp: "2020-12-15T00:09:52Z"
  generation: 1
  name: virtual-mesh
  namespace: gloo-mesh
  resourceVersion: "7680"
  selfLink: /apis/networking.mesh.gloo.solo.io/v1alpha2/namespaces/gloo-mesh/virtualmeshes/virtual-mesh
  uid: df5675aa-e121-43a2-8d0c-55c5009a4b8a
spec:
  federation:
    permissive: {}
  meshes:
  - name: istiod-istio-system-cluster1
    namespace: gloo-mesh
  - name: istiod-istio-system-cluster2
    namespace: gloo-mesh
  mtlsConfig:
    autoRestartPods: true
    shared:
      rootCertificateAuthority:
        generated: {}
status:
  meshes:
    istiod-istio-system-cluster1.gloo-mesh.:
      state: ACCEPTED
    istiod-istio-system-cluster2.gloo-mesh.:
      state: ACCEPTED
  observedGeneration: 1
  state: ACCEPTED
```

without:
```yaml
apiVersion: networking.mesh.gloo.solo.io/v1alpha2
kind: VirtualMesh
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"networking.mesh.gloo.solo.io/v1alpha2","kind":"VirtualMesh","metadata":{"annotations":{},"name":"virtual-mesh","namespace":"gloo-mesh"},"spec":{"federation":{"permissive":{}},"meshes":[{"name":"istiod-istio-system-cluster1","namespace":"gloo-mesh"},{"name":"istiod-istio-system-cluster2","namespace":"gloo-mesh"}],"mtlsConfig":{"autoRestartPods":true,"shared":{"rootCertificateAuthority":{"generated":{}}}}}}
  creationTimestamp: "2020-12-15T00:09:52Z"
  generation: 1
  name: virtual-mesh
  namespace: gloo-mesh
  resourceVersion: "10658"
  selfLink: /apis/networking.mesh.gloo.solo.io/v1alpha2/namespaces/gloo-mesh/virtualmeshes/virtual-mesh
  uid: df5675aa-e121-43a2-8d0c-55c5009a4b8a
spec:
  federation:
    permissive: {}
  meshes:
  - name: istiod-istio-system-cluster1
    namespace: gloo-mesh
  - name: istiod-istio-system-cluster2
    namespace: gloo-mesh
  mtlsConfig:
    autoRestartPods: true
    shared:
      rootCertificateAuthority:
        generated: {}
status:
  errors:
  - 'write error: admission webhook "validation.istio.io" denied the request: configuration
    is invalid: unsupported protocol: UnsupportedProtocol'
  - 'write error: admission webhook "validation.istio.io" denied the request: configuration
    is invalid: unsupported protocol: UnsupportedProtocol'
  meshes:
    istiod-istio-system-cluster1.gloo-mesh.:
      state: ACCEPTED
    istiod-istio-system-cluster2.gloo-mesh.:
      state: ACCEPTED
  observedGeneration: 1
  state: FAILED
```