### PR TITLE
Rest traffic policy status correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ endif
 
 .PHONY: cert-agent-image-load
 cert-agent-image-load: cert-agent-image
-    kind load docker-image --name mgmt-cluster $(CA_IMAGE):$(VERSION)
+	kind load docker-image --name mgmt-cluster $(CA_IMAGE):$(VERSION)
 
 
 #----------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ endif
 
 .PHONY: gloo-mesh-image-load
 gloo-mesh-image-load: gloo-mesh-image
-    kind load docker-image --name mgmt-cluster $(GLOOMESH_IMAGE):$(VERSION)
+	kind load docker-image --name mgmt-cluster $(GLOOMESH_IMAGE):$(VERSION)
 
 #----------------------------------------------------------------------------------
 # Build cert-agent + image

--- a/changelog/v0.12.7/traffic_policy_status.yaml
+++ b/changelog/v0.12.7/traffic_policy_status.yaml
@@ -1,4 +1,4 @@
 changelog:
   - type: FIX
     issueLink: https://github.com/solo-io/gloo-mesh/issues/1232
-    description: Reset trafifc policy status correctly so deleted traffic targets are removed.
+    description: Reset traffic policy status correctly so deleted traffic targets are removed.

--- a/changelog/v0.12.7/traffic_policy_status.yaml
+++ b/changelog/v0.12.7/traffic_policy_status.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo-mesh/issues/1232
+    description: Reset trafifc policy status correctly so deleted traffic targets are removed.

--- a/pkg/mesh-networking/apply/applier.go
+++ b/pkg/mesh-networking/apply/applier.go
@@ -63,7 +63,6 @@ func (v *applier) Apply(ctx context.Context, input input.LocalSnapshot, userSupp
 
 // Optimistically initialize policy statuses to accepted, which may be set to invalid or failed pending subsequent validation.
 func initializePolicyStatuses(input input.LocalSnapshot) {
-
 	trafficPolicies := input.TrafficPolicies().List()
 	accessPolicies := input.AccessPolicies().List()
 	failoverServices := input.FailoverServices().List()
@@ -74,7 +73,7 @@ func initializePolicyStatuses(input input.LocalSnapshot) {
 		trafficPolicy.Status = networkingv1alpha2.TrafficPolicyStatus{
 			State:              networkingv1alpha2.ApprovalState_ACCEPTED,
 			ObservedGeneration: trafficPolicy.Generation,
-			TrafficTargets:     trafficPolicy.Status.TrafficTargets,
+			TrafficTargets:     map[string]*networkingv1alpha2.ApprovalStatus{},
 		}
 	}
 


### PR DESCRIPTION
Starting traffic policy status:

```yaml
status:
  observedGeneration: 1
  state: ACCEPTED
  trafficTargets:
    details-bookinfo-mgmt-cluster.gloo-mesh.:
      state: ACCEPTED
    reviews-bookinfo-mgmt-cluster.gloo-mesh.:
      state: ACCEPTED
  workloads:
  - details-v1-bookinfo-mgmt-cluster-deployment.gloo-mesh.
  - istio-ingressgateway-istio-system-mgmt-cluster-deployment.gloo-mesh.
  - productpage-v1-bookinfo-mgmt-cluster-deployment.gloo-mesh.
  - ratings-v1-bookinfo-mgmt-cluster-deployment.gloo-mesh.
  - reviews-v1-bookinfo-mgmt-cluster-deployment.gloo-mesh.
  - reviews-v2-bookinfo-mgmt-cluster-deployment.gloo-mesh.
  ```

Status after details service is deleted (pre-fix):

```yaml
status:
  errors:
  - TrafficTarget details.bookinfo.mgmt-cluster not found
  observedGeneration: 1
  state: INVALID
  trafficTargets:
    details-bookinfo-mgmt-cluster.gloo-mesh.:
      state: ACCEPTED
    reviews-bookinfo-mgmt-cluster.gloo-mesh.:
      state: ACCEPTED
  workloads:
  - details-v1-bookinfo-mgmt-cluster-deployment.gloo-mesh.
  - istio-ingressgateway-istio-system-mgmt-cluster-deployment.gloo-mesh.
  - productpage-v1-bookinfo-mgmt-cluster-deployment.gloo-mesh.
  - ratings-v1-bookinfo-mgmt-cluster-deployment.gloo-mesh.
  - reviews-v1-bookinfo-mgmt-cluster-deployment.gloo-mesh.
  - reviews-v2-bookinfo-mgmt-cluster-deployment.gloo-mesh.
  - reviews-v3-bookinfo-mgmt-cluster-deployment.gloo-mesh.
```

Status after details service is deleted (post-fix):

```yaml
status:
  errors:
  - TrafficTarget details.bookinfo.mgmt-cluster not found
  observedGeneration: 1
  state: INVALID
```

The traffic policy YAML I tested with is in the comments of the associated issue.
BOT NOTES: 
resolves https://github.com/solo-io/gloo-mesh/issues/1232