### PR TITLE
Simplify license scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,10 +265,10 @@ endif
 .PHONY: update-licenses
 update-licenses:
 	# check for GPL licenses, if there are any, this will fail
-	cd hack/oss_compliance; GO111MODULE=on go run main.go osagen -c "GNU General Public License v2.0,GNU General Public License v3.0,GNU Lesser General Public License v2.1,GNU Lesser General Public License v3.0,GNU Affero General Public License v3.0"
+	GO111MODULE=on go run hack/oss_compliance/main.go osagen -c "GNU General Public License v2.0,GNU General Public License v3.0,GNU Affero General Public License v3.0"
 
-	cd hack/oss_compliance; GO111MODULE=on go run main.go osagen -s "Mozilla Public License 2.0,GNU General Public License v2.0,GNU General Public License v3.0,GNU Lesser General Public License v2.1,GNU Lesser General Public License v3.0,GNU Affero General Public License v3.0"> ../../docs/content/static/content/osa_provided.txt
-	cd hack/oss_compliance; GO111MODULE=on go run main.go osagen -i "Mozilla Public License 2.0,GNU General Public License v2.0,GNU General Public License v3.0,GNU Lesser General Public License v2.1,GNU Lesser General Public License v3.0,GNU Affero General Public License v3.0"> ../../docs/content/static/content/osa_included.txt
+	GO111MODULE=on go run hack/oss_compliance/main.go osagen -s "Mozilla Public License 2.0,GNU General Public License v2.0,GNU General Public License v3.0,GNU Lesser General Public License v2.1,GNU Lesser General Public License v3.0,GNU Affero General Public License v3.0"> docs/content/static/content/osa_provided.txt
+	GO111MODULE=on go run hack/oss_compliance/main.go osagen -i "Mozilla Public License 2.0,GNU General Public License v2.0,GNU General Public License v3.0,GNU Lesser General Public License v2.1,GNU Lesser General Public License v3.0,GNU Affero General Public License v3.0"> docs/content/static/content/osa_included.txt
 
 
 #----------------------------------------------------------------------------------

--- a/changelog/v1.0.0-beta2/simplify-license-scanning.yaml
+++ b/changelog/v1.0.0-beta2/simplify-license-scanning.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Updated license scanning code to skip checking for Lesser GPL licenses and automated scanning all gloo mesh packages.

--- a/changelog/v1.0.0-beta2/simplify-license-scanning.yaml
+++ b/changelog/v1.0.0-beta2/simplify-license-scanning.yaml
@@ -1,3 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: Updated license scanning code to skip checking for Lesser GPL licenses and automated scanning all gloo mesh packages.

--- a/changelog/v1.0.0-beta3/simplify-license-scanning.yaml
+++ b/changelog/v1.0.0-beta3/simplify-license-scanning.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Updated license scanning code to skip checking for Lesser GPL licenses and automated scanning all gloo mesh packages.

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/solo-io/anyvendor v0.0.3
 	github.com/solo-io/external-apis v0.1.4
-	github.com/solo-io/go-list-licenses v0.1.0
+	github.com/solo-io/go-list-licenses v0.1.3
 	github.com/solo-io/go-utils v0.20.4
 	github.com/solo-io/k8s-utils v0.0.3
 	github.com/solo-io/protoc-gen-ext v0.0.15

--- a/go.sum
+++ b/go.sum
@@ -1272,6 +1272,8 @@ github.com/solo-io/external-apis v0.1.4/go.mod h1:3vyADtIZj8hCD5cBUwGuA60hd8O5fa
 github.com/solo-io/go-list-licenses v0.0.4/go.mod h1:x6LSp/NrYgVXwNum7ZOiaAYTpg6B3F6TrWYfcdHVroA=
 github.com/solo-io/go-list-licenses v0.1.0 h1:8FkdOtyiX8ga305U60tQbihXVpsZCWkWQH2uz4rqIMM=
 github.com/solo-io/go-list-licenses v0.1.0/go.mod h1:x6LSp/NrYgVXwNum7ZOiaAYTpg6B3F6TrWYfcdHVroA=
+github.com/solo-io/go-list-licenses v0.1.3 h1:jMbYURUSu5G47p7ijcQFkx+xLYlmd0RKqHmi+nlUywg=
+github.com/solo-io/go-list-licenses v0.1.3/go.mod h1:x6LSp/NrYgVXwNum7ZOiaAYTpg6B3F6TrWYfcdHVroA=
 github.com/solo-io/go-utils v0.19.0/go.mod h1:If8NiehXROCFU65PGeDTrrZCNA5gJXvbcVoXI8Fqjko=
 github.com/solo-io/go-utils v0.20.0 h1:R6NYnFw+SOi1ThTMIlJbFnB3W0vnu8exu+raaUE26jI=
 github.com/solo-io/go-utils v0.20.0/go.mod h1:wy4um9xnqPNlASld4eSuQQqjNCXRBtDjVRLJsoGqkdE=

--- a/go.sum
+++ b/go.sum
@@ -1270,8 +1270,6 @@ github.com/solo-io/anyvendor v0.0.3/go.mod h1:xHZ0KMrsG620iI4VnRDJGJ1gk8bR79HG/t
 github.com/solo-io/external-apis v0.1.4 h1:OEZ8+3puweHeS0ltDlcbCgL89LLaIEraw+x4e9mQPuM=
 github.com/solo-io/external-apis v0.1.4/go.mod h1:3vyADtIZj8hCD5cBUwGuA60hd8O5faQKvfUl400brLY=
 github.com/solo-io/go-list-licenses v0.0.4/go.mod h1:x6LSp/NrYgVXwNum7ZOiaAYTpg6B3F6TrWYfcdHVroA=
-github.com/solo-io/go-list-licenses v0.1.0 h1:8FkdOtyiX8ga305U60tQbihXVpsZCWkWQH2uz4rqIMM=
-github.com/solo-io/go-list-licenses v0.1.0/go.mod h1:x6LSp/NrYgVXwNum7ZOiaAYTpg6B3F6TrWYfcdHVroA=
 github.com/solo-io/go-list-licenses v0.1.3 h1:jMbYURUSu5G47p7ijcQFkx+xLYlmd0RKqHmi+nlUywg=
 github.com/solo-io/go-list-licenses v0.1.3/go.mod h1:x6LSp/NrYgVXwNum7ZOiaAYTpg6B3F6TrWYfcdHVroA=
 github.com/solo-io/go-utils v0.19.0/go.mod h1:If8NiehXROCFU65PGeDTrrZCNA5gJXvbcVoXI8Fqjko=

--- a/hack/oss_compliance/main.go
+++ b/hack/oss_compliance/main.go
@@ -8,19 +8,17 @@ import (
 )
 
 func main() {
-	glooMeshPackages := []string{
-		"github.com/solo-io/gloo-mesh/cmd/cert-agent/",
-		"github.com/solo-io/gloo-mesh/cmd/meshctl/",
-		"github.com/solo-io/gloo-mesh/cmd/gloo-mesh/",
-	}
-	// dependencies for this package which are used on mac, and will not be present in linux CI
 	macOnlyDependencies := []string{
 		"github.com/mitchellh/go-homedir",
 		"github.com/containerd/continuity",
 	}
-	app := license.Cli(glooMeshPackages, macOnlyDependencies)
+	app, err := license.CliAllPackages(macOnlyDependencies)
+	if err != nil {
+		fmt.Println("unable to gather all gloo mesh packages")
+		os.Exit(1)
+	}
 	if err := app.Execute(); err != nil {
-		fmt.Errorf("unable to run oss compliance check: %v\n", err)
+		fmt.Printf("unable to run oss compliance check: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Updated license scanning code to skip checking for Lesser GPL licenses and automated scanning all gloo mesh packages.