### PR TITLE
Remove docsgen go.sum hack

### DIFF
--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -76,12 +76,6 @@ for version in "${versions[@]}"; do
     git checkout tags/v"$version"
   fi
 
-  # Fix the cidranger checksum issue on old version
-  # Only required until we remove support for versions before 0.12.7
-  if [[ "$version" != "1."* ]] && [[ "$version" != "0.12."* ]]; then
-    sed -i 's#h1:L7Msw4X7EQK7zMVjOtv7o8xMyjv1rJcNlYlMgGwP7ko=#h1:9U1yz7WPYDwf0vpNWFaeRh0bjwz5RVgRy/9UEQfHl0g=#' go.sum
-  fi
-
   # Replace version with "latest" if it's the latest version. This enables URLs with "/latest/..."
   [[ "$version" ==  "$latestVersion" ]] && version="latest"
 


### PR DESCRIPTION
It appears that the checksum error that occurs when testing locally:
```
verifying github.com/yl2chen/cidranger@v1.0.0/go.mod: checksum mismatch
        downloaded: h1:9U1yz7WPYDwf0vpNWFaeRh0bjwz5RVgRy/9UEQfHl0g=
        go.sum:     h1:L7Msw4X7EQK7zMVjOtv7o8xMyjv1rJcNlYlMgGwP7ko=
```
Does not occur in GItHub actions, from the logs here it looks like its expecting the old checksum for cidrranger: https://github.com/solo-io/gloo-mesh/runs/2116608124#step:8:597

