### PR TITLE
Don't regen reference docs during CI

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -30,7 +30,9 @@ site-common: clean
 	if [ ! -d themes/hugo-theme-soloio ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio; fi
 	# style updates for putting docs in the dev-portal repo, see details here https://github.com/solo-io/hugo-theme-soloio/commit/e0c50784a92fb7f61c635ff9a6e3a010f636f550
 	git -C themes/hugo-theme-soloio checkout $(SOLO_HUGO_THEME)
-	go run cmd/docsgen.go
+	# Don't regenerate the CLI and API when building the site
+	# Should already be version controlled
+	ONLY_CHANGELOG=true go run cmd/docsgen.go
 
 .PHONY: site-test
 site-test: site-common

--- a/docs/docsgen/generate_proto_docs.go
+++ b/docs/docsgen/generate_proto_docs.go
@@ -60,6 +60,9 @@ func generateProtoDocs(protoDir, templateFile, destDir string) error {
 	links = collectLinks(destDir, docsTemplate)
 
 	templateContents, err := ioutil.ReadFile(templateFile)
+	if err != nil {
+		return err
+	}
 
 	tmpl, err := template.New(templateFile).Funcs(templateFuncs(links)).Parse(string(templateContents))
 	if err != nil {
@@ -107,6 +110,9 @@ func removeDescriptions(file *gendoc.File) {
 func generateProtoDocsIndex(descriptors *gendoc.Template, links map[string]string, destDir string) error {
 
 	templateContents, err := ioutil.ReadFile(protoIndexTemplate)
+	if err != nil {
+		return err
+	}
 
 	tmpl, err := template.New(protoIndexTemplate).Funcs(templateFuncs(links)).Parse(string(templateContents))
 	if err != nil {

--- a/docs/docsgen/generate_reference_docs.go
+++ b/docs/docsgen/generate_reference_docs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -104,7 +105,7 @@ type Options struct {
 
 func Execute(opts Options) error {
 	rootDir := filepath.Join(moduleRoot, opts.DocsRoot)
-	if os.Getenv("ONLY_CHANGELOG") == "" {
+	if !checkEnvVariable("ONLY_CHANGELOG") {
 		if err := generateCliReference(rootDir, opts.Cli); err != nil {
 			return err
 		}
@@ -133,7 +134,7 @@ func generateCliReference(root string, opts CliOptions) error {
 }
 
 func generateChangelog(root string, opts ChangelogOptions) error {
-	if os.Getenv("SKIP_CHANGELOG_GENERATION") != "" {
+	if checkEnvVariable("SKIP_CHANGELOG_GENERATION") {
 		return nil
 	}
 	// flush directory for idempotence
@@ -251,4 +252,13 @@ func getGitVersion() (string, error) {
 	}
 
 	return strings.TrimSpace(string(version)), nil
+}
+
+func checkEnvVariable(key string) bool {
+	val := os.Getenv(key)
+	if val == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(val)
+	return err != nil || b // treat set env variables as true
 }

--- a/docs/docsgen/generate_reference_docs.go
+++ b/docs/docsgen/generate_reference_docs.go
@@ -104,11 +104,13 @@ type Options struct {
 
 func Execute(opts Options) error {
 	rootDir := filepath.Join(moduleRoot, opts.DocsRoot)
-	if err := generateCliReference(rootDir, opts.Cli); err != nil {
-		return err
-	}
-	if err := generateApiDocs(rootDir, opts.Proto); err != nil {
-		return err
+	if os.Getenv("ONLY_CHANGELOG") == "" {
+		if err := generateCliReference(rootDir, opts.Cli); err != nil {
+			return err
+		}
+		if err := generateApiDocs(rootDir, opts.Proto); err != nil {
+			return err
+		}
 	}
 	if err := generateChangelog(rootDir, opts.Changelog); err != nil {
 		return err


### PR DESCRIPTION
Fixes the empty API docs by not regenerating the versioned control reference docs (CLI and API) during CI. Only the changelog will be generated at CI time.