### PR TITLE
Minor docs improvements

### DIFF
--- a/docs/content/guides/_index.md
+++ b/docs/content/guides/_index.md
@@ -84,17 +84,20 @@ You'll want to first have [Istio installed for multi-cluster]({{% versioned_link
 
 The core components, including reviews-v1 and reviews-v2, are deployed to the management plane cluster, while `reviews-v3` is deployed on the remote cluster.
 
-Deploy part of the bookinfo application to the `mgmt-cluster` cluster:
-
 {{% notice note %}}
 Be sure to switch the `kubeconfig` context to the `mgmt-cluster`
-{{% /notice %}}
+{{% /notice %}
+
+Before running the following, make sure your context names are set as environment variables:
 
 ```shell
-# Set the proper context value for each cluster
 MGMT_CONTEXT=your_management_plane_context
 REMOTE_CONTEXT=your_remote_context
+```
 
+Deploy part of the bookinfo application to the `mgmt-cluster` cluster:
+
+```shell
 kubectl config use-context $MGMT_CONTEXT
 
 kubectl create ns bookinfo

--- a/docs/content/guides/_index.md
+++ b/docs/content/guides/_index.md
@@ -86,7 +86,7 @@ The core components, including reviews-v1 and reviews-v2, are deployed to the ma
 
 {{% notice note %}}
 Be sure to switch the `kubeconfig` context to the `mgmt-cluster`
-{{% /notice %}
+{{% /notice %}}
 
 Before running the following, make sure your context names are set as environment variables:
 

--- a/docs/content/guides/access_control_intro.md
+++ b/docs/content/guides/access_control_intro.md
@@ -23,7 +23,6 @@ Be sure to review the assumptions and satisfy the pre-requisites from the [Guide
 
 ## Enforcing Access Control
 
-
 Ensure that your kubeconfig has the correct context set as its `currentContext`:
 
 ```shell
@@ -46,7 +45,7 @@ Let's use the Gloo Mesh [AccessPolicy]({{% versioned_link_path fromRoot="/refere
 In the previous guide, [we created a VirtualMesh resource]({{% versioned_link_path fromRoot="/guides/federate_identity/#creating-a-virtual-mesh" %}}), but we had access control disabled. Let's take a look at the same VirtualService, with access control enabled:
 
 {{< tabs >}}
-{{< tab name="YAML file" codelang="shell">}}
+{{< tab name="YAML file" codelang="yaml">}}
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: VirtualMesh
 metadata:
@@ -120,7 +119,7 @@ To allow traffic to continue as before, we apply the following two updates our c
 In this configuration, we select sources (in this case the `productpage` service account) and allow traffic the any service in the `bookinfo` namespace. Be sure to update the `clusterName` value as needed.
 
 {{< tabs >}}
-{{< tab name="YAML file" codelang="shell">}}
+{{< tab name="YAML file" codelang="yaml">}}
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: AccessPolicy
 metadata:
@@ -171,7 +170,7 @@ accesspolicy.networking.mesh.gloo.solo.io/productpage created
 In this next configuration, we enable traffic from `reviews` to `ratings`:
 
 {{< tabs >}}
-{{< tab name="YAML file" codelang="shell">}}
+{{< tab name="YAML file" codelang="yaml">}}
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: AccessPolicy
 metadata:

--- a/docs/content/guides/access_logging.md
+++ b/docs/content/guides/access_logging.md
@@ -31,7 +31,7 @@ both `mgmt-cluster` and `remote-cluster` have the necessary configuration for
 Gloo Mesh access logging. View the Istio ConfigMap with the following command:
 
 ```shell
-kubectl --context MGMT_CONTEXT -n istio-system get configmap istio -oyaml
+kubectl --context $MGMT_CONTEXT -n istio-system get configmap istio -oyaml
 ```
 
 Ensure that the following highlighted entries exist in the ConfigMap:
@@ -60,7 +60,8 @@ for which to enable collection as well as request/response level filter criteria
 
 For demonstration purposes let's create the following object:
 
-```yaml
+{{< tabs >}}
+{{< tab name="YAML file" codelang="yaml">}}
 apiVersion: observability.enterprise.mesh.gloo.solo.io/v1
 kind: AccessLogRecord
 metadata:
@@ -71,7 +72,22 @@ spec:
     - headerMatcher:
         name: foo
         value: bar
-```
+{{< /tab >}}
+{{< tab name="CLI inline" codelang="shell" >}}
+kubectl apply --context $MGMT_CONTEXT -f - << EOF
+apiVersion: observability.enterprise.mesh.gloo.solo.io/v1
+kind: AccessLogRecord
+metadata:
+  name: access-log-all
+  namespace: gloo-mesh
+spec:
+  filters:
+  - headerMatcher:
+      name: foo
+      value: bar
+EOF
+{{< /tab >}}
+{{< /tabs >}}
 
 This will enable access log collection for all workloads in both clusters, but only
 for requests containing the header `"foo": "bar"`.
@@ -81,11 +97,11 @@ for requests containing the header `"foo": "bar"`.
 Let's first generate some access logs by making requests in both clusters:
 
 ```shell
-kubectl --context MGMT_CONTEXT -n bookinfo exec -it deploy/ratings-v1 -c ratings --  curl -H "foo: bar" -v reviews:9080/reviews/1
+kubectl --context $MGMT_CONTEXT -n bookinfo exec -it deploy/ratings-v1 -c ratings --  curl -H "foo: bar" -v reviews:9080/reviews/1
 ```
 
 ```shell
-kubectl --context REMOTE_CONTEXT -n bookinfo exec -it deploy/ratings-v1 -c ratings --  curl -H "foo: bar" -v reviews:9080/reviews/1
+kubectl --context $REMOTE_CONTEXT -n bookinfo exec -it deploy/ratings-v1 -c ratings --  curl -H "foo: bar" -v reviews:9080/reviews/1
 ```
 
 Assuming the access logs were collected successfully, we can now retrieve them, either
@@ -98,7 +114,7 @@ port to your local machine by running the following:
 
 ```shell
 # forward port 8080 from enterprise-networking to localhost:8080
-kubectl --context MGMT_CONTEXT -n gloo-mesh port-forward deploy/enterprise-networking 8080
+kubectl --context $MGMT_CONTEXT -n gloo-mesh port-forward deploy/enterprise-networking 8080
 ```
 
 The following command will fetch up to 10 of the latest access logs.
@@ -256,7 +272,8 @@ spec:
 Next, create the following Istio DestinationRule which is intentionally erroroneous,
 the referenced TLS secret data does not exist.
 
-```yaml
+{{< tabs >}}
+{{< tab name="YAML file" codelang="yaml">}}
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -271,7 +288,26 @@ spec:
       clientCertificate: /etc/certs/myclientcert.pem
       privateKey: /etc/certs/client_private_key.pem
       caCertificates: /etc/certs/rootcacerts.pem
-```
+{{< /tab >}}
+{{< tab name="CLI inline" codelang="shell" >}}
+kubectl apply --context $REMOTE_CONTEXT -f - << EOF
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: ratings
+  namespace: bookinfo
+spec:
+  host: ratings.bookinfo.svc.cluster.local
+    trafficPolicy:
+      tls:
+        mode: MUTUAL
+        # these files do not exist
+        clientCertificate: /etc/certs/myclientcert.pem
+        privateKey: /etc/certs/client_private_key.pem
+        caCertificates: /etc/certs/rootcacerts.pem
+EOF
+{{< /tab >}}
+{{< /tabs >}}
 
 Sending a request from the `productpage` pod to the ratings Destination should yield 
 the following access log:

--- a/docs/content/guides/configure_role_based_api.md
+++ b/docs/content/guides/configure_role_based_api.md
@@ -52,7 +52,6 @@ Permissive mode is enabled by setting the environment variable `RBAC_PERMISSIVE_
 
 ```yaml
 licenseKey: LICENSE_KEY_STRING
-
 rbac-webhook:
   rbacWebhook:
     env:

--- a/docs/content/guides/multicluster_communication.md
+++ b/docs/content/guides/multicluster_communication.md
@@ -24,7 +24,7 @@ Be sure to review the assumptions and satisfy the pre-requisites from the [Guide
 We will now perform a *multi-cluster traffic split*, splitting traffic from the `productpage` service in the `mgmt-cluster` cluster between `reviews-v1`, `reviews-v2`, and `reviews-v3` running in the `remote-cluster` cluster.
 
 {{< tabs >}}
-{{< tab name="YAML file" codelang="shell">}}
+{{< tab name="YAML file" codelang="yaml">}}
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: TrafficPolicy
 metadata:

--- a/docs/content/guides/traffic_policy.md
+++ b/docs/content/guides/traffic_policy.md
@@ -119,7 +119,27 @@ We are going to create a TrafficPolicy that uses the `petstore-default-mgmt-clus
 
 Here is the configuration we will apply:
 
-```shell
+{{< tabs >}}
+{{< tab name="YAML file" codelang="yaml">}}
+apiVersion: networking.mesh.gloo.solo.io/v1
+kind: TrafficPolicy
+metadata:
+  namespace: gloo-mesh
+  name: petstore
+spec:
+  destinationSelector:
+  - kubeServiceRefs:
+      services:
+      - clusterName: mgmt-cluster
+        name: petstore
+        namespace: default
+  policy:
+    requestTimeout: 100ms 
+    retries:
+      attempts: 5
+      perTryTimeout: 5ms
+{{< /tab >}}
+{{< tab name="CLI inline" codelang="shell" >}}
 kubectl apply --context $MGMT_CONTEXT -f - << EOF
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: TrafficPolicy
@@ -130,16 +150,17 @@ spec:
   destinationSelector:
   - kubeServiceRefs:
       services:
-        - clusterName: mgmt-cluster
-          name: petstore
-          namespace: default
+      - clusterName: mgmt-cluster
+        name: petstore
+        namespace: default
   policy:
-    requestTimeout: 100ms
+    requestTimeout: 100ms 
     retries:
       attempts: 5
       perTryTimeout: 5ms
 EOF
-```
+{{< /tab >}}
+{{< /tabs >}}
 
 We are using the `destinationSelector` property to specify a single Kubernetes service on the management cluster. We could specify multiple services across several clusters, along with setting up a Virtual Mesh and Multicluster communication. The request timeout is being set to 100ms and there is a maximum of five attempts before an error will be returned.
 

--- a/docs/content/guides/using_role_based_api.md
+++ b/docs/content/guides/using_role_based_api.md
@@ -25,6 +25,12 @@ To illustrate these concepts, we will assume that:
 Be sure to review the assumptions and satisfy the pre-requisites from the [Guides]({{% versioned_link_path fromRoot="/guides" %}}) top-level document.
 {{% /notice %}}
 
+Ensure you have the correct context names set in your environment:
+
+```shell
+MGMT_CONTEXT=your_management_plane_context
+```
+
 ## Role-based API
 
 The role-based API in Gloo Mesh Enterprise uses a `Role` Custom Resource Definition to create Custom Resources that represent roles you would like to define. The roles are then bound to users with a `RoleBinding` CRD. 
@@ -46,8 +52,27 @@ That might be good for testing, but certainly shouldn't be done in a production 
 
 Let's try and create a network policy on our Gloo Mesh Enterprise deployment without first creating a role and binding.
 
-```shell
-MGMT_CONTEXT=<your management plane cluster>
+{{< tabs >}}
+{{< tab name="YAML file" codelang="yaml">}}
+apiVersion: networking.mesh.gloo.solo.io/v1
+kind: TrafficPolicy
+metadata:
+  namespace: gloo-mesh
+  name: petstore
+spec:
+  destinationSelector:
+  - kubeServiceRefs:
+      services:
+        - clusterName: mgmt-cluster
+          name: petstore
+          namespace: default
+  policy:
+    requestTimeout: 100ms
+    retries:
+      attempts: 5
+      perTryTimeout: 5ms
+{{< /tab >}}
+{{< tab name="CLI inline" codelang="shell" >}}
 kubectl apply --context $MGMT_CONTEXT -f - << EOF
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: TrafficPolicy
@@ -67,7 +92,8 @@ spec:
       attempts: 5
       perTryTimeout: 5ms
 EOF
-```
+{{< /tab >}}
+{{< /tabs >}}
 
 ```shell
 Error from server (User kubernetes-admin does not have the permissions necessary to perform this action.): error when creating "STDIN": admission webhook "rbac-webhook.gloo-mesh.svc" denied the request: User kubernetes-admin does not have the permissions necessary to perform this action.
@@ -110,7 +136,26 @@ createAdminRole: true
 Assuming that you've granted yourself admin permissions, if we try to create a Gloo Mesh resource again,
 the result should be successful:
 
-```shell
+{{< tabs >}}
+{{< tab name="YAML file" codelang="yaml">}}
+apiVersion: networking.mesh.gloo.solo.io/v1
+kind: TrafficPolicy
+metadata:
+  namespace: gloo-mesh
+  name: petstore
+spec:
+  destinationSelector:
+  - kubeServiceRefs:
+      services:
+        - clusterName: mgmt-cluster
+          name: petstore
+          namespace: default
+  requestTimeout: 100ms
+  retries:
+    attempts: 5
+    perTryTimeout: 5ms
+{{< /tab >}}
+{{< tab name="CLI inline" codelang="shell" >}}
 kubectl apply --context $MGMT_CONTEXT -f - << EOF
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: TrafficPolicy
@@ -129,7 +174,8 @@ spec:
     attempts: 5
     perTryTimeout: 5ms
 EOF
-```
+{{< /tab >}}
+{{< /tabs >}}
 
 ```shell
 trafficpolicy.networking.mesh.gloo.solo.io/petstore created
@@ -147,7 +193,10 @@ The Destination Consumer Role also creates an AccessPolicyScope defining where a
 
 The end result is that the role allows the management of AccessPolicies for a specific identity and Destination, and allows a small number of TrafficPolicyActions on a specific service and workload. This type of fine-grained permissions could then be bound to a developer or operator responsible for managing traffic.
 
-```yaml
+You can deploy the following role:
+
+{{< tabs >}}
+{{< tab name="YAML file" codelang="yaml">}}
 apiVersion: rbac.enterprise.mesh.gloo.solo.io/v1
 kind: Role
 metadata:
@@ -193,17 +242,64 @@ spec:
               - name: ratings
                 namespace: bookinfo
                 clusterName: "*"
-```
-
-You can save the above role to the file `destination-consumer.yaml` and deploy it with the following command:
-
-```shell
-kubectl --context $MGMT_CONTEXT apply -f destination-consumer.yaml
-```
+{{< /tab >}}
+{{< tab name="CLI inline" codelang="shell" >}}
+kubectl apply --context $MGMT_CONTEXT -f - << EOF
+apiVersion: rbac.enterprise.mesh.gloo.solo.io/v1
+kind: Role
+metadata:
+  name: destination-consumer-role
+  namespace: gloo-mesh
+spec:
+  # A Destination consumer has the ability to configure policies that affect the network edge between
+  # a specific workload and an upstream Destination.
+  trafficPolicyScopes:
+    - trafficPolicyActions:
+        - RETRIES
+        - REQUEST_TIMEOUT
+        - FAULT_INJECTION
+      destinationSelectors:
+        # The absence of kubeServiceMatcher disallows selecting Destinations by kubeServiceMatcher
+        - kubeServiceRefs:
+            services:
+              - name: ratings
+                namespace: bookinfo
+                clusterName: "*"
+      workloadSelectors:
+        - kubeWorkloadMatcher:
+            labels:
+              app: productpage
+              version: v1
+            namespaces:
+              - bookinfo
+            clusters:
+              - "*"
+  # An empty virtualMeshScopes field means that no virtual mesh actions are allowed
+  # An empty failoverServiceScopes field means that no failover services can be applied by this role bearer
+  accessPolicyScopes:
+    - identitySelectors:
+        - kubeServiceAccountRefs:
+            serviceAccounts:
+              - name: "productpage"
+                namespace: "bookinfo"
+                clusterName: "*"
+    - destinationSelectors:
+        # The absence of kubeServiceMatcher disallows selecting Destinations by kubeServiceMatcher
+        - kubeServiceRefs:
+            services:
+              - name: ratings
+                namespace: bookinfo
+                clusterName: "*"
+EOF
+{{< /tab >}}
+{{< /tabs >}}
 
 Now we can bind the role to our junior operator, Gloo.
 
-```yaml
+You can now apply the following binding:
+
+{{< tabs >}}
+{{< tab name="YAML file" codelang="yaml">}}
 apiVersion: rbac.enterprise.mesh.gloo.solo.io/v1
 kind: RoleBinding
 metadata:
@@ -218,13 +314,26 @@ spec:
   subjects:
     - kind: User
       name: Gloo
-```
-
-You can save the above binding to the file `destination-consumer-binding.yaml` and deploy it with the following command:
-
-```shell
-kubectl --context $MGMT_CONTEXT apply -f destination-consumer-binding.yaml
-```
+{{< /tab >}}
+{{< tab name="CLI inline" codelang="shell" >}}
+kubectl apply --context $MGMT_CONTEXT -f - << EOF
+apiVersion: rbac.enterprise.mesh.gloo.solo.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: gloo-mesh
+  name: destination-consumer-role-binding
+  namespace: gloo-mesh
+spec:
+  roleRef:
+    name: destination-consumer-role
+    namespace: gloo-mesh
+  subjects:
+    - kind: User
+      name: Gloo
+EOF
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Summary and Next Steps
 

--- a/docs/content/setup/cluster_registration/community_cluster_registration.md
+++ b/docs/content/setup/cluster_registration/community_cluster_registration.md
@@ -50,7 +50,7 @@ Note that the `--cluster-name` is NOT the name of the cluster in your kubeconfig
 {{% /notice %}}
 
 ```shell
-INFO[0003] successfully registered cluster remote-cluster
+successfully registered cluster remote-cluster
 ```
 
 You can validate the registration by looking at the Custom Resource created in the management cluster:
@@ -116,7 +116,7 @@ meshctl cluster register community mgmt-cluster \
 {{< /tabs >}}
 
 ```
-INFO[0003] successfully registered cluster mgmt-cluster
+successfully registered cluster mgmt-cluster
 ```
 
 ## What happened?


### PR DESCRIPTION
Few changes to the docs:
- Use the YAML and cli-inline tab setup for all commands in the guides
- Remove the placeholder `MGMT_CONTEXT=your_management_cluster` stuff to their own code blocks to make it easier for users to copy/paste blocks without manually replacing the placeholder values.
- Other small typos