### PR TITLE
python3 in install script

### DIFF
--- a/changelog/v1.1.0-beta10/python3-in-install.yaml
+++ b/changelog/v1.1.0-beta10/python3-in-install.yaml
@@ -1,5 +1,5 @@
 changelog:
-  - type: BUG_FIX
+  - type: FIX
     issueLink: https://github.com/solo-io/gloo-mesh/issues/1386
     description: >
       Fix the meshctl install script to use either python3 or python2 for installation, instead of

--- a/changelog/v1.1.0-beta10/python3-in-install.yaml
+++ b/changelog/v1.1.0-beta10/python3-in-install.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: BUG_FIX
+    issueLink: https://github.com/solo-io/gloo-mesh/issues/1386
+    description: >
+      Fix the meshctl install script to use either python3 or python2 for installation, instead of
+      accepting only  python2.

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -3,11 +3,11 @@
 set -eu
 
 if [ -x "$(command -v python3)" ]; then
-  echo Using Python3 to install meshctl
   alias any_python='python3'
 elif [ -x "$(command -v python)" ]; then
-  echo Using Python2 to install meshctl
   alias any_python='python'    
+elif [ -x "$(command -v python2)" ]; then
+  alias any_python='python2'    
 else
   echo Python 2 or 3 is required to install meshctl
   exit 1

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -2,13 +2,19 @@
 
 set -eu
 
-if ! [ -x "$(command -v python)" ]; then
-     echo Python is required to install meshctl
-     exit 1
- fi
+if [ -x "$(command -v python3)" ]; then
+  echo Using Python3 to install meshctl
+  alias any_python='python3'
+elif [ -x "$(command -v python)" ]; then
+  echo Using Python2 to install meshctl
+  alias any_python='python'    
+else
+  echo Python 2 or 3 is required to install meshctl
+  exit 1
+fi
 
 if [ -z "${GLOO_MESH_VERSION:-}" ]; then
-  GLOO_MESH_VERSIONS=$(curl -sH"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo-mesh/releases | python -c "import sys; from distutils.version import StrictVersion, LooseVersion; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases];  filtered_releases = list(filter(lambda release_string: len(release_string) > 0 and StrictVersion.version_re.match(release_string[1:]) != None, releases)); filtered_releases.sort(key=LooseVersion, reverse=True); print('\n'.join(filtered_releases))")
+  GLOO_MESH_VERSIONS=$(curl -sH"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo-mesh/releases | any_python -c "import sys; from distutils.version import StrictVersion, LooseVersion; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases];  filtered_releases = list(filter(lambda release_string: len(release_string) > 0 and StrictVersion.version_re.match(release_string[1:]) != None, releases)); filtered_releases.sort(key=LooseVersion, reverse=True); print('\n'.join(filtered_releases))")
 else
   GLOO_MESH_VERSIONS="${GLOO_MESH_VERSION}"
 fi


### PR DESCRIPTION
Modifies the python-checking login in the meshctl install script to check for both python 2 and 3, and use either (preferring 3).
BOT NOTES: 
resolves https://github.com/solo-io/gloo-mesh/issues/1386