### PR TITLE
meshctl check nits

### DIFF
--- a/changelog/v1.1.0-beta14/meshctl-nits.yaml
+++ b/changelog/v1.1.0-beta14/meshctl-nits.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: Improve wording of meshctl check cluster output column names and hint message.
+    issueLink: https://github.com/solo-io/gloo-mesh/issues/1562
+


### PR DESCRIPTION
Changed the column names to be more informative, albiet long. Also changed the check logic for when it fails. Originally I was going to remove agentsPulling entirely from the first check, but it occurred to me that zero pulls is indicative of a problematic agent connection, regardless of the dashboard situation.

New look passing:
<img width="607" alt="Screen Shot 2021-06-18 at 3 50 13 PM" src="https://user-images.githubusercontent.com/5865634/122610792-3929cf80-d04e-11eb-8fc5-0c3492b78f9c.png">

new look failing:
<img width="600" alt="Screen Shot 2021-06-18 at 3 50 38 PM" src="https://user-images.githubusercontent.com/5865634/122610803-3c24c000-d04e-11eb-9d7c-55c27887f464.png">

BOT NOTES: 
resolves https://github.com/solo-io/gloo-mesh/issues/1562