### PR TITLE
Integration testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run:
           name: install deps
           command: |
-            make install-go-tools
+            make install-go-tools install-test-tools
       - run:
           name: e2e istio 1.5 tests
           no_output_timeout: 30m

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -59,7 +59,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Unit Tests
         run: |
-          make install-go-tools run-tests
+          make install-go-tools install-test-tools run-tests
 
   e2e-istio:
     name: end-to-end-istio

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,17 @@ mod-download:
 clear-vendor-any:
 	rm -rf vendor_any
 
+# Dependencies for testing
+K8S_VERSION=1.19.2
+.PHONY: install-test-tools
+install-test-tools: mod-download
+	# documented here: https://book.kubebuilder.io/reference/envtest.html
+
+	curl -sSLo envtest-bins.tar.gz "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-$(K8S_VERSION)-$(shell go env GOOS)-$(shell go env GOARCH).tar.gz"
+	tar -C $(DEPSGOBIN) --strip-components=1 -zvxf envtest-bins.tar.gz
+	rm envtest-bins.tar.gz
+	export KUBEBUILDER_ASSETS=$(DEPSGOBIN)/bin
+
 # Dependencies for code generation
 .PHONY: install-go-tools
 install-go-tools: mod-download

--- a/docs/content/reference/helm/gloo_mesh/latest/_index.md
+++ b/docs/content/reference/helm/gloo_mesh/latest/_index.md
@@ -1,6 +1,6 @@
 
 ---
-title: "v1.1.0-beta32"
+title: "v1.1.0-beta34"
 description: Reference for Helm values. 
 weight: 2
 ---

--- a/pkg/mesh-networking/start.go
+++ b/pkg/mesh-networking/start.go
@@ -52,23 +52,24 @@ func Start(ctx context.Context, opts *NetworkingOpts) error {
 // custom entryoint for the Networking Reconciler. Used to allow running a customized/extended version of the Networking Reconciler.
 // disableMultiCluster - disable multi cluster manager and clientset from being initialized
 func StartFunc(opts *NetworkingOpts, makeExtensions MakeExtensionOpts) bootstrap.StartFunc {
-	starter := networkingStarter{
+	starter := NetworkingStarter{
 		NetworkingOpts: opts,
-		makeExtensions: makeExtensions,
+		MakeExtensions: makeExtensions,
 	}
-	return starter.startReconciler
+	return starter.StartReconciler
 }
 
-type networkingStarter struct {
+// exported for tests
+type NetworkingStarter struct {
 	*NetworkingOpts
 
 	// callback to configure extensions
-	makeExtensions MakeExtensionOpts
+	MakeExtensions MakeExtensionOpts
 }
 
 // start the main reconcile loop
-func (s networkingStarter) startReconciler(ctx context.Context, parameters bootstrap.StartParameters) error {
-	extensionOpts := s.makeExtensions(ctx, parameters)
+func (s NetworkingStarter) StartReconciler(ctx context.Context, parameters bootstrap.StartParameters) error {
+	extensionOpts := s.MakeExtensions(ctx, parameters)
 	extensionOpts.initDefaults(parameters)
 
 	baseTranslator := certissuertranslation.NewTranslator(corev1clients.NewSecretClient(parameters.MasterManager.GetClient()))

--- a/test/integration/robustness/resources/istio/bookinfo.go
+++ b/test/integration/robustness/resources/istio/bookinfo.go
@@ -1,0 +1,20 @@
+package istio
+
+import (
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var  (
+	WorkloadNamespace = "bookinfo"
+
+	BookinfoNamespaceObj = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: WorkloadNamespace,
+				Labels: map[string]string{
+					injection.RevisionInjectionLabelName: IstioRevsion,
+				},
+			},
+		}
+)

--- a/test/integration/robustness/resources/istio/istio.go
+++ b/test/integration/robustness/resources/istio/istio.go
@@ -1,0 +1,90 @@
+package istio
+
+import (
+	istiov1alpha1 "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pkg/util/protomarshal"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	IstioNamespace = "istio-namespace"
+	IstioRevsion = "best-revision-ever"
+	IstioServiceAccount = "service-account-name"
+	IstiodDeploymentName = "istiod"
+	IstioTrustDomain = "cluster.suffix"
+
+
+	// istio namespace
+	IstioNamespaceObj = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: IstioNamespace,
+		},
+	}
+
+	// istiod deployment
+	IstiodDeploymentObj = &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: IstioNamespace,
+			Name:      IstiodDeploymentName,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "istiod"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "istiod",
+							Image: "istio-pilot:latest",
+						},
+					},
+					ServiceAccountName: IstioServiceAccount,
+				},
+			},
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "istiod"},
+			},
+		},
+	}
+
+	// istio meshconfig configmap
+	IstioMeshConfigConfigMapObj = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istio",
+			Namespace: IstioNamespace,
+		},
+		Data: map[string]string{
+			"mesh": func()string {
+				meshConfig := &istiov1alpha1.MeshConfig{
+					TrustDomain: IstioTrustDomain,
+				}
+				meshConfigYaml, err := protomarshal.ToYAML(meshConfig)
+				if err != nil {
+					panic(err)
+				}
+				return meshConfigYaml
+			}(),
+		},
+	}
+
+	// istio ingress gateway
+	IstioIngressGatewayServiceObj = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istio-ingress",
+			Namespace: IstioNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			ExternalIPs: []string{"12.34.56.78"},
+			Ports: []corev1.ServicePort{{
+				Name:     "tls",
+				Protocol: "TCP",
+				Port:     1234,
+			}},
+			Selector: map[string]string{"istio": "ingressgateway"},
+			Type:     corev1.ServiceTypeLoadBalancer,
+		},
+	}
+)

--- a/test/integration/robustness/robustness_suite_test.go
+++ b/test/integration/robustness/robustness_suite_test.go
@@ -3,7 +3,6 @@ package robustness_test
 import (
 	"context"
 
-	"log"
 	"os"
 	"testing"
 	"time"

--- a/test/integration/robustness/robustness_suite_test.go
+++ b/test/integration/robustness/robustness_suite_test.go
@@ -1,0 +1,181 @@
+package robustness_test
+
+import (
+	"context"
+
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo-mesh/pkg/certificates/agent"
+	"github.com/solo-io/gloo-mesh/pkg/common/defaults"
+	"github.com/solo-io/gloo-mesh/pkg/common/schemes"
+	mesh_discovery "github.com/solo-io/gloo-mesh/pkg/mesh-discovery"
+	"github.com/solo-io/gloo-mesh/pkg/mesh-discovery/reconciliation"
+	mesh_networking "github.com/solo-io/gloo-mesh/pkg/mesh-networking"
+	"github.com/solo-io/gloo-mesh/test/utils"
+	"github.com/solo-io/go-utils/errgroup"
+	"github.com/solo-io/skv2/codegen/util"
+	v1 "github.com/solo-io/skv2/pkg/api/core.skv2.solo.io/v1"
+	"github.com/solo-io/skv2/pkg/bootstrap"
+	"github.com/solo-io/skv2/pkg/stats"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+/*
+todo:
+- reproduce the issue by deleting workloads in the cluster and watching the issuedcert get recreated. can also watch the vmesh status.
+- write integration test (maybe e2e?) to repro it. run both discovery and networking components in the test in memory with fake clients
+- solutions to implement:
+   - workload discovery decouple from pods
+   - destionation discovery decouple from workload
+   - persist last known good mesh config
+
+*/
+
+//NOTE: set USE_EXISTING_CLUSTER=1 to use a real k8s cluster. Otherwise envtest will use controller-runtime's envtest to spin up a local apiserver.
+
+func TestRobustness(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Robustness Suite")
+}
+
+// paths to the directories containing networking and agent crds
+var (
+	ctx     = context.TODO()
+	crdDirs = []string{
+		util.MustGetThisDir() + "/../../../install/helm/agent-crds/crds",
+		util.MustGetThisDir() + "/../../../install/helm/gloo-mesh-crds/crds",
+	}
+
+	mgmtMgr   manager.Manager
+	remoteMgr manager.Manager
+
+	params bootstrap.StartParameters
+)
+
+var _ = BeforeSuite(func() {
+	envtestAssets := os.Getenv("KUBEBUILDER_ASSETS")
+	if envtestAssets == "" {
+		Fail("KUBEBUILDER_ASSETS not set. Run `make install-test-tools` to install integration test assets")
+	}
+
+	mgmtMgr, remoteMgr = runManager(), runManager()
+
+	managers := map[string]manager.Manager{
+		"mgmt-cluster":   mgmtMgr,
+		"remote-cluster": remoteMgr,
+	}
+	mcWatcher := utils.FakeClusterWatcher{
+		RootCtx:            ctx,
+		PerClusterManagers: managers,
+	}
+	mcClient := utils.FakeMulticlusterClient{
+		PerClusterManagers: managers,
+	}
+
+	params = bootstrap.StartParameters{
+		MasterManager:   mgmtMgr,
+		McClient:        mcClient,
+		Clusters:        mcWatcher,
+		SnapshotHistory: stats.NewSnapshotHistory(), // just to prevent panic
+		SettingsRef: v1.ObjectRef{
+			Name:      defaults.DefaultSettingsName,
+			Namespace: defaults.GetPodNamespace(),
+		},
+		VerboseMode: true,
+	}
+
+	startGlooMeshComponents()
+})
+
+func runManager() manager.Manager {
+	env := envtest.Environment{
+		CRDDirectoryPaths: crdDirs,
+	}
+	cfg, err := env.Start()
+	Expect(err).NotTo(HaveOccurred())
+	s := scheme.Scheme
+	err = schemes.AddToScheme(s)
+	Expect(err).NotTo(HaveOccurred())
+	mgr, err := manager.New(cfg, manager.Options{
+		Scheme:             s,
+		MetricsBindAddress: "0",
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	return mgr
+}
+
+func startGlooMeshComponents() {
+
+	ctx := context.TODO()
+
+	eg, ctx := errgroup.WithContext(ctx)
+
+	// start networking
+	eg.Go(func() error {
+		netOpts := &mesh_networking.NetworkingOpts{
+			Options: &bootstrap.Options{},
+		}
+		netOpts.AddToFlags(&pflag.FlagSet{}) // just to set defaults
+
+		return mesh_networking.NetworkingStarter{
+			NetworkingOpts: netOpts,
+			MakeExtensions: func(ctx context.Context, parameters bootstrap.StartParameters) mesh_networking.ExtensionOpts {
+				// no extensions
+				return mesh_networking.ExtensionOpts{}
+			},
+		}.StartReconciler(ctx, params)
+	})
+
+	// start discovery
+	eg.Go(func() error {
+		discOpts := &mesh_discovery.DiscoveryOpts{
+			Options: &bootstrap.Options{},
+		}
+		discOpts.AddToFlags(&pflag.FlagSet{}) // just to set defaults
+
+		return reconciliation.Start(
+			ctx,
+			"",
+			params.MasterManager,
+			params.Clusters,
+			params.McClient,
+			params.SnapshotHistory,
+			params.VerboseMode,
+			&params.SettingsRef,
+		)
+	})
+
+	// start cert agent on mgmt cluster
+	eg.Go(func() error {
+		return agent.StartWithManager(ctx, mgmtMgr, agent.CertAgentReconcilerExtensionOpts{})
+	})
+
+	// start cert agent on remote cluster
+	eg.Go(func() error {
+		return agent.StartWithManager(ctx, remoteMgr, agent.CertAgentReconcilerExtensionOpts{})
+	})
+
+	go func() {
+		defer GinkgoRecover()
+		err := eg.Wait()
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// give components 3 sec to start
+	time.Sleep(time.Second * 3)
+}

--- a/test/integration/robustness/robustness_suite_test.go
+++ b/test/integration/robustness/robustness_suite_test.go
@@ -188,6 +188,7 @@ type testState struct {
 
 // applies the input resources of the state to each cluster and verifies eventually they are consistent
 func (s testState) execute(ctx context.Context) {
+	By(s.description)
 	eg, ctx := errgroup.WithContext(ctx)
 	for mgr, state := range s.clusterStates {
 		for _, obj := range state.clusterInputs {

--- a/test/integration/robustness/robustness_test.go
+++ b/test/integration/robustness/robustness_test.go
@@ -1,8 +1,9 @@
 package robustness_test
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -17,7 +18,7 @@ import (
 var _ = Describe("Robustness", func() {
 	var (
 		// upsert an obj
-		upsert = func (mgr manager.Manager, obj client.Object) {
+		upsert = func(mgr manager.Manager, obj client.Object) {
 			_, err := controllerutils.Upsert(ctx, mgr.GetClient(), obj.DeepCopyObject().(client.Object))
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		}

--- a/test/integration/robustness/robustness_test.go
+++ b/test/integration/robustness/robustness_test.go
@@ -1,42 +1,22 @@
 package robustness_test
 
 import (
+	. "github.com/onsi/ginkgo"
 	v1 "github.com/solo-io/gloo-mesh/pkg/api/discovery.mesh.gloo.solo.io/v1"
 	settingsv1 "github.com/solo-io/gloo-mesh/pkg/api/settings.mesh.gloo.solo.io/v1"
 	"github.com/solo-io/gloo-mesh/pkg/common/defaults"
-	istiov1alpha1 "istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
-	"istio.io/istio/pkg/util/protomarshal"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"time"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
+	"github.com/solo-io/gloo-mesh/test/integration/robustness/resources/istio"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var _ = Describe("Robustness", func() {
-
-	It("upserts virtual mesh outputs to enable federation", func() {
-		workloadNamespace := "bookinfo"
-		istioNamespace := "istio-namespace"
-		istioRevsion := "best-revision-ever"
-		istioServiceAccount := "service-account-name"
-		istiodDeploymentName := "istiod"
-		trustDomain := "cluster.suffix"
-
-		meshConfig := &istiov1alpha1.MeshConfig{
-			TrustDomain: trustDomain,
-		}
-		meshConfigYaml, err := protomarshal.ToYAML(meshConfig)
-		Expect(err).To(BeNil())
-
+	It("deterministically translates inputs into expected outputs", func() {
 		testCase{states: []testState{
 			{
-				description: "virtual mesh outputs created when a virtual mesh is applied to multiple meshes",
+				description: "mesh detected when istiod present",
 				clusterStates: map[manager.Manager]configState{
 					mgmtMgr: {
 						clusterInputs: []client.Object{
@@ -55,7 +35,7 @@ var _ = Describe("Robustness", func() {
 							},
 						},
 						clusterExpectedOutputs: []client.Object{
-							// discovered mesh
+							// discovered east mesh
 							&v1.Mesh{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      "istiod-istio-namespace-remote-east",
@@ -68,21 +48,58 @@ var _ = Describe("Robustness", func() {
 								},
 								Spec: v1.MeshSpec{
 									Type: &v1.MeshSpec_Istio_{Istio: &v1.MeshSpec_Istio{
-										Installation:            &v1.MeshInstallation{
-											Namespace: istioNamespace,
+										Installation: &v1.MeshInstallation{
+											Namespace: istio.IstioNamespace,
 											Cluster:   "remote-east",
 											PodLabels: map[string]string{
 												"app": "istiod",
 											},
-											Version:   "latest",
-											Region:    "",
+											Version: "latest",
+											Region:  "",
 										},
-										TrustDomain:             trustDomain,
-										IstiodServiceAccount:    istioServiceAccount,
+										TrustDomain:          istio.IstioTrustDomain,
+										IstiodServiceAccount: istio.IstioServiceAccount,
 										IngressGateways: []*v1.MeshSpec_Istio_IngressGatewayInfo{{
 											Name:                "istio-ingress",
-											Namespace:           istioNamespace,
-											WorkloadLabels:       map[string]string{"istio": "ingressgateway"},
+											Namespace:           istio.IstioNamespace,
+											WorkloadLabels:      map[string]string{"istio": "ingressgateway"},
+											ExternalAddress:     "12.34.56.78",
+											ExternalAddressType: &v1.MeshSpec_Istio_IngressGatewayInfo_Ip{Ip: "12.34.56.78"},
+											ExternalTlsPort:     1234,
+											TlsContainerPort:    1234,
+										}},
+										SmartDnsProxyingEnabled: false,
+									}},
+								},
+							},
+							// discovered west mesh
+							&v1.Mesh{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "istiod-istio-namespace-remote-west",
+									Namespace: "gloo-mesh",
+									Labels: map[string]string{
+										"cluster.discovery.mesh.gloo.solo.io": "remote-west",
+										"cluster.multicluster.solo.io":        "",
+										"owner.discovery.mesh.gloo.solo.io":   "gloo-mesh",
+									},
+								},
+								Spec: v1.MeshSpec{
+									Type: &v1.MeshSpec_Istio_{Istio: &v1.MeshSpec_Istio{
+										Installation: &v1.MeshInstallation{
+											Namespace: istio.IstioNamespace,
+											Cluster:   "remote-west",
+											PodLabels: map[string]string{
+												"app": "istiod",
+											},
+											Version: "latest",
+											Region:  "",
+										},
+										TrustDomain:          istio.IstioTrustDomain,
+										IstiodServiceAccount: istio.IstioServiceAccount,
+										IngressGateways: []*v1.MeshSpec_Istio_IngressGatewayInfo{{
+											Name:                "istio-ingress",
+											Namespace:           istio.IstioNamespace,
+											WorkloadLabels:      map[string]string{"istio": "ingressgateway"},
 											ExternalAddress:     "12.34.56.78",
 											ExternalAddressType: &v1.MeshSpec_Istio_IngressGatewayInfo_Ip{Ip: "12.34.56.78"},
 											ExternalTlsPort:     1234,
@@ -96,98 +113,24 @@ var _ = Describe("Robustness", func() {
 					},
 					remoteEastMgr: {
 						clusterInputs: []client.Object{
-							// istio namespace
-							&corev1.Namespace{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: istioNamespace,
-								},
-							},
-							// istiod deployment
-							&appsv1.Deployment{
-								ObjectMeta: metav1.ObjectMeta{
-									Namespace: istioNamespace,
-									Name:      istiodDeploymentName,
-								},
-								Spec: appsv1.DeploymentSpec{
-									Template: corev1.PodTemplateSpec{
-										ObjectMeta: metav1.ObjectMeta{
-											Labels: map[string]string{"app": "istiod"},
-										},
-										Spec: corev1.PodSpec{
-											Containers: []corev1.Container{
-												{
-													Name:  "istiod",
-													Image: "istio-pilot:latest",
-												},
-											},
-											ServiceAccountName: istioServiceAccount,
-										},
-									},
-									Selector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{"app": "istiod"},
-									},
-								},
-							},
-							// istio meshconfig configmap
-							&corev1.ConfigMap{
-								ObjectMeta: metav1.ObjectMeta{
-									Name:      "istio",
-									Namespace: istioNamespace,
-								},
-								Data: map[string]string{
-									"mesh": meshConfigYaml,
-								},
-							},
-							// istio ingress gateway
-							&corev1.Service{
-								ObjectMeta: metav1.ObjectMeta{
-									Name:      "istio-ingress",
-									Namespace: istioNamespace,
-								},
-								Spec: corev1.ServiceSpec{
-									ExternalIPs: []string{"12.34.56.78"},
-									Ports: []corev1.ServicePort{{
-										Name:     "tls",
-										Protocol: "TCP",
-										Port:     1234,
-									}},
-									Selector: map[string]string{"istio": "ingressgateway"},
-									Type:     corev1.ServiceTypeLoadBalancer,
-								},
-							},
-
-							// injected workload namespace
-							&corev1.Namespace{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: workloadNamespace,
-									Labels: map[string]string{
-										injection.RevisionInjectionLabelName: istioRevsion,
-									},
-								},
-							},
+							istio.IstioNamespaceObj,
+							istio.IstiodDeploymentObj,
+							istio.IstioMeshConfigConfigMapObj,
+							istio.IstioIngressGatewayServiceObj,
 						},
 						clusterExpectedOutputs: nil,
 					},
 					remoteWestMgr: {
-						clusterInputs:          nil,
+						clusterInputs: []client.Object{
+							istio.IstioNamespaceObj,
+							istio.IstiodDeploymentObj,
+							istio.IstioMeshConfigConfigMapObj,
+							istio.IstioIngressGatewayServiceObj,
+						},
 						clusterExpectedOutputs: nil,
 					},
 				},
 			},
 		}}.execute(rootCtx)
-
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(func() (*v1.Workload, error) {
-			workloads, err := v1.NewWorkloadClient(mgmtMgr.GetClient()).ListWorkload(rootCtx)
-			if err != nil {
-				return nil, err
-			}
-			if len(workloads.Items) == 0 {
-				return nil, nil
-			}
-			return &workloads.Items[0], nil
-		}, time.Minute).ShouldNot(BeNil())
-
-		time.Sleep(time.Minute * 5)
 	})
 })

--- a/test/integration/robustness/robustness_test.go
+++ b/test/integration/robustness/robustness_test.go
@@ -1,0 +1,146 @@
+package robustness_test
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/skv2/pkg/controllerutils"
+	"github.com/solo-io/skv2/pkg/resource"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Robustness", func() {
+	var (
+		// upsert an obj
+		upsert = func (mgr manager.Manager, obj client.Object) {
+			_, err := controllerutils.Upsert(ctx, mgr.GetClient(), obj.DeepCopyObject().(client.Object))
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		}
+	)
+
+	It("do", func() {
+		gateway := makeService(
+			"gateway",
+			"istio",
+			map[string]string{"app": "istio-ingressgateway"},
+			[]corev1.Container{
+				{
+					Name:  "doesntmatter",
+					Image: "doesntmatter",
+				},
+			},
+			80,
+		)
+		istiod := makeService(
+			"istiod",
+			"istio",
+			map[string]string{"app": "istiod"},
+			[]corev1.Container{
+				{
+					Name:  "doesntmatter",
+					Image: "istio-pilot:latest",
+				},
+			},
+			15001,
+		)
+		reviews := makeService(
+			"reviews",
+			"bookinfo",
+			map[string]string{"app": "reviews"},
+			[]corev1.Container{
+				{
+					Name:  "doesntmatter",
+					Image: "istio-proxy:latest",
+				},
+			},
+			9080,
+		)
+
+		discoverableResources := []resource.TypedObject{
+			makeNamespace("istio", nil),
+			makeNamespace("bookinfo", map[string]string{
+				"sidecar.istio.io/inject": "true",
+			}),
+			gateway.Deployment,
+			gateway.Service,
+			istiod.Deployment,
+			istiod.Service,
+			reviews.Deployment,
+			reviews.Service,
+		}
+
+		for _, res := range discoverableResources {
+			upsert(mgmtMgr, res)
+			upsert(remoteMgr, res)
+		}
+
+		time.Sleep(time.Minute * 5)
+	})
+})
+
+type deployedService struct {
+	Deployment *appsv1.Deployment
+	Service    *corev1.Service
+}
+
+func makeNamespace(
+	name string,
+	labels map[string]string,
+) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+func makeService(
+	name, namespace string,
+	labels map[string]string,
+	containers []corev1.Container,
+	port int32,
+) *deployedService {
+	return &deployedService{
+		Deployment: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    labels,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+						Labels:    labels,
+					},
+					Spec: corev1.PodSpec{
+						Containers: containers,
+					},
+				},
+			},
+		},
+		Service: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    labels,
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: labels,
+				Ports: []corev1.ServicePort{{
+					Port: port,
+				}},
+			},
+		},
+	}
+}

--- a/test/integration/robustness/robustness_test.go
+++ b/test/integration/robustness/robustness_test.go
@@ -1,147 +1,193 @@
 package robustness_test
 
 import (
-	"time"
-
+	v1 "github.com/solo-io/gloo-mesh/pkg/api/discovery.mesh.gloo.solo.io/v1"
+	settingsv1 "github.com/solo-io/gloo-mesh/pkg/api/settings.mesh.gloo.solo.io/v1"
+	"github.com/solo-io/gloo-mesh/pkg/common/defaults"
+	istiov1alpha1 "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
+	"istio.io/istio/pkg/util/protomarshal"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/solo-io/skv2/pkg/controllerutils"
-	"github.com/solo-io/skv2/pkg/resource"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Robustness", func() {
-	var (
-		// upsert an obj
-		upsert = func(mgr manager.Manager, obj client.Object) {
-			_, err := controllerutils.Upsert(ctx, mgr.GetClient(), obj.DeepCopyObject().(client.Object))
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
-	)
 
-	It("do", func() {
-		gateway := makeService(
-			"gateway",
-			"istio",
-			map[string]string{"app": "istio-ingressgateway"},
-			[]corev1.Container{
-				{
-					Name:  "doesntmatter",
-					Image: "doesntmatter",
+	It("upserts virtual mesh outputs to enable federation", func() {
+		workloadNamespace := "bookinfo"
+		istioNamespace := "istio-namespace"
+		istioRevsion := "best-revision-ever"
+		istioServiceAccount := "service-account-name"
+		istiodDeploymentName := "istiod"
+		trustDomain := "cluster.suffix"
+
+		meshConfig := &istiov1alpha1.MeshConfig{
+			TrustDomain: trustDomain,
+		}
+		meshConfigYaml, err := protomarshal.ToYAML(meshConfig)
+		Expect(err).To(BeNil())
+
+		testCase{states: []testState{
+			{
+				description: "virtual mesh outputs created when a virtual mesh is applied to multiple meshes",
+				clusterStates: map[manager.Manager]configState{
+					mgmtMgr: {
+						clusterInputs: []client.Object{
+							// gloo mesh namespace
+							&corev1.Namespace{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: defaults.GetPodNamespace(),
+								},
+							},
+							// gloo mesh settings
+							&settingsv1.Settings{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      defaults.DefaultSettingsName,
+									Namespace: defaults.GetPodNamespace(),
+								},
+							},
+						},
+						clusterExpectedOutputs: []client.Object{
+							// discovered mesh
+							&v1.Mesh{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "istiod-istio-namespace-remote-east",
+									Namespace: "gloo-mesh",
+									Labels: map[string]string{
+										"cluster.discovery.mesh.gloo.solo.io": "remote-east",
+										"cluster.multicluster.solo.io":        "",
+										"owner.discovery.mesh.gloo.solo.io":   "gloo-mesh",
+									},
+								},
+								Spec: v1.MeshSpec{
+									Type: &v1.MeshSpec_Istio_{Istio: &v1.MeshSpec_Istio{
+										Installation:            &v1.MeshInstallation{
+											Namespace: istioNamespace,
+											Cluster:   "remote-east",
+											PodLabels: map[string]string{
+												"app": "istiod",
+											},
+											Version:   "latest",
+											Region:    "",
+										},
+										TrustDomain:             trustDomain,
+										IstiodServiceAccount:    istioServiceAccount,
+										IngressGateways: []*v1.MeshSpec_Istio_IngressGatewayInfo{{
+											Name:                "istio-ingress",
+											Namespace:           istioNamespace,
+											WorkloadLabels:       map[string]string{"istio": "ingressgateway"},
+											ExternalAddress:     "12.34.56.78",
+											ExternalAddressType: &v1.MeshSpec_Istio_IngressGatewayInfo_Ip{Ip: "12.34.56.78"},
+											ExternalTlsPort:     1234,
+											TlsContainerPort:    1234,
+										}},
+										SmartDnsProxyingEnabled: false,
+									}},
+								},
+							},
+						},
+					},
+					remoteEastMgr: {
+						clusterInputs: []client.Object{
+							// istio namespace
+							&corev1.Namespace{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: istioNamespace,
+								},
+							},
+							// istiod deployment
+							&appsv1.Deployment{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: istioNamespace,
+									Name:      istiodDeploymentName,
+								},
+								Spec: appsv1.DeploymentSpec{
+									Template: corev1.PodTemplateSpec{
+										ObjectMeta: metav1.ObjectMeta{
+											Labels: map[string]string{"app": "istiod"},
+										},
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name:  "istiod",
+													Image: "istio-pilot:latest",
+												},
+											},
+											ServiceAccountName: istioServiceAccount,
+										},
+									},
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"app": "istiod"},
+									},
+								},
+							},
+							// istio meshconfig configmap
+							&corev1.ConfigMap{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "istio",
+									Namespace: istioNamespace,
+								},
+								Data: map[string]string{
+									"mesh": meshConfigYaml,
+								},
+							},
+							// istio ingress gateway
+							&corev1.Service{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "istio-ingress",
+									Namespace: istioNamespace,
+								},
+								Spec: corev1.ServiceSpec{
+									ExternalIPs: []string{"12.34.56.78"},
+									Ports: []corev1.ServicePort{{
+										Name:     "tls",
+										Protocol: "TCP",
+										Port:     1234,
+									}},
+									Selector: map[string]string{"istio": "ingressgateway"},
+									Type:     corev1.ServiceTypeLoadBalancer,
+								},
+							},
+
+							// injected workload namespace
+							&corev1.Namespace{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: workloadNamespace,
+									Labels: map[string]string{
+										injection.RevisionInjectionLabelName: istioRevsion,
+									},
+								},
+							},
+						},
+						clusterExpectedOutputs: nil,
+					},
+					remoteWestMgr: {
+						clusterInputs:          nil,
+						clusterExpectedOutputs: nil,
+					},
 				},
 			},
-			80,
-		)
-		istiod := makeService(
-			"istiod",
-			"istio",
-			map[string]string{"app": "istiod"},
-			[]corev1.Container{
-				{
-					Name:  "doesntmatter",
-					Image: "istio-pilot:latest",
-				},
-			},
-			15001,
-		)
-		reviews := makeService(
-			"reviews",
-			"bookinfo",
-			map[string]string{"app": "reviews"},
-			[]corev1.Container{
-				{
-					Name:  "doesntmatter",
-					Image: "istio-proxy:latest",
-				},
-			},
-			9080,
-		)
+		}}.execute(rootCtx)
 
-		discoverableResources := []resource.TypedObject{
-			makeNamespace("istio", nil),
-			makeNamespace("bookinfo", map[string]string{
-				"sidecar.istio.io/inject": "true",
-			}),
-			gateway.Deployment,
-			gateway.Service,
-			istiod.Deployment,
-			istiod.Service,
-			reviews.Deployment,
-			reviews.Service,
-		}
-
-		for _, res := range discoverableResources {
-			upsert(mgmtMgr, res)
-			upsert(remoteMgr, res)
-		}
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() (*v1.Workload, error) {
+			workloads, err := v1.NewWorkloadClient(mgmtMgr.GetClient()).ListWorkload(rootCtx)
+			if err != nil {
+				return nil, err
+			}
+			if len(workloads.Items) == 0 {
+				return nil, nil
+			}
+			return &workloads.Items[0], nil
+		}, time.Minute).ShouldNot(BeNil())
 
 		time.Sleep(time.Minute * 5)
 	})
 })
-
-type deployedService struct {
-	Deployment *appsv1.Deployment
-	Service    *corev1.Service
-}
-
-func makeNamespace(
-	name string,
-	labels map[string]string,
-) *corev1.Namespace {
-	return &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: labels,
-		},
-	}
-}
-
-func makeService(
-	name, namespace string,
-	labels map[string]string,
-	containers []corev1.Container,
-	port int32,
-) *deployedService {
-	return &deployedService{
-		Deployment: &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-				Labels:    labels,
-			},
-			Spec: appsv1.DeploymentSpec{
-				Selector: &metav1.LabelSelector{
-					MatchLabels: labels,
-				},
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: namespace,
-						Labels:    labels,
-					},
-					Spec: corev1.PodSpec{
-						Containers: containers,
-					},
-				},
-			},
-		},
-		Service: &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-				Labels:    labels,
-			},
-			Spec: corev1.ServiceSpec{
-				Selector: labels,
-				Ports: []corev1.ServicePort{{
-					Port: port,
-				}},
-			},
-		},
-	}
-}

--- a/test/utils/fake_multicluster.go
+++ b/test/utils/fake_multicluster.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"context"
+	"sort"
+
+	"github.com/rotisserie/eris"
+	"github.com/solo-io/skv2/pkg/multicluster"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// FakeMulticlusterClient wraps a set of rest configs for multiple clusters
+type FakeMulticlusterClient struct {
+	// pre load your own managers here
+	PerClusterManagers map[string]manager.Manager
+}
+
+var _ multicluster.Client = FakeMulticlusterClient{}
+
+func (f FakeMulticlusterClient) ListClusters() []string {
+	var clusters []string
+	for cluster := range f.PerClusterManagers {
+		clusters = append(clusters, cluster)
+	}
+	sort.Strings(clusters)
+	return clusters
+}
+
+func (f FakeMulticlusterClient) Cluster(name string) (client.Client, error) {
+	m, ok := f.PerClusterManagers[name]
+	if !ok {
+		return nil, eris.Errorf("no manager found for cluster %v", name)
+	}
+	return m.GetClient(), nil
+}
+
+// FakeMulticlusterClient wraps a set of rest configs for multiple clusters
+type FakeClusterWatcher struct {
+	// shared root ctx
+	RootCtx context.Context
+	// pre load your own managers here
+	PerClusterManagers map[string]manager.Manager
+}
+
+var _ multicluster.Interface = FakeClusterWatcher{}
+
+func (f FakeClusterWatcher) Run(_ manager.Manager) error {
+	return nil
+}
+
+func (f FakeClusterWatcher) RegisterClusterHandler(handler multicluster.ClusterHandler) {
+	// only works if the clusters have been added first
+	for cluster, mgr := range f.PerClusterManagers {
+		cluster := cluster // pike
+		mgr := mgr         // pike
+		go func() {
+			// run in a goroutine
+			// as to not block
+			handler.AddCluster(
+				f.RootCtx,
+				cluster,
+				mgr,
+			)
+		}()
+	}
+}
+
+func (f FakeClusterWatcher) Cluster(cluster string) (manager.Manager, error) {
+	m, ok := f.PerClusterManagers[cluster]
+	if !ok {
+		return nil, eris.Errorf("no manager found for cluster %v", cluster)
+	}
+	return m, nil
+}
+
+func (f FakeClusterWatcher) ListClusters() []string {
+	var clusters []string
+	for cluster := range f.PerClusterManagers {
+		clusters = append(clusters, cluster)
+	}
+	sort.Strings(clusters)
+	return clusters
+}

--- a/test/utils/module.go
+++ b/test/utils/module.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// get the file path to a go module
+func GetModulePath(modName string) string {
+	res, err := exec.Command("go", "list", "-f", "{{ .Dir }}", "-m", modName).CombinedOutput()
+	if err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(string(res))
+}


### PR DESCRIPTION
adds "integration testing" for our components - all components run simultaneously pointed at mock kube apiservers which impersonate clusters. supports blackbox testing of our translation pipeline all in-process of one go process